### PR TITLE
If source for --name doesn't exist, generate nice error message, not JS error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 apis/
+api/
 elm-stuff/
 node_modules/
 sandbox/

--- a/bin/elm-aws-generate.js
+++ b/bin/elm-aws-generate.js
@@ -48,7 +48,6 @@ const issue = 'Please open an issue on https://github.com/ktonon/elm-aws-generat
 co(function* () {
   yield sourceApi.download(name, { root, refresh });
   const source = sourceApi.findLatest(name, { root });
-  const { protocol, signatureVersion } = source.metadata;
 
   if (!source) {
     console.error(`Could not find source JSON file for "${name}".
@@ -57,6 +56,8 @@ If that does not help, make sure a service exists with the given name.
 See https://github.com/aws/aws-sdk-js/tree/master/apis for available services.`);
     process.exit(1);
   }
+
+  const { protocol, signatureVersion } = source.metadata;
 
   if (source.version !== '2.0') {
     console.error(`Unsupported source version: ${source.version}.\n${issue}`);


### PR DESCRIPTION
Before I learned to use "s3" instead of "s3-2006-03-01.normal" or "s3-2006-03-01", I was getting a JS error. The error detection was there, but AFTER the extraction of the protocol and signatureVersion properties from the metadata of the void "source".

Of course, this didn't help me much, since S3 has a so-far unsupported signatureVersion ("s3") and protocol ("rest-xml"), but it at least gets a nice error message for an unknown service name.